### PR TITLE
Update Toggle Specs.sketchplugin

### DIFF
--- a/Toggle Specs.sketchplugin
+++ b/Toggle Specs.sketchplugin
@@ -2,24 +2,42 @@
 
 var layername = "specs";
 var pages = [doc pages];
+var visibility = nil;  // whether all specs will be toggled on or off (vs toggling each layer independently)
 
 for (var a=0; a<pages.length();a++){
-	var currentPage = pages[a];
-	var artboards = [currentPage artboards];
+	var page = pages[a];
+	var artboards = [page artboards];
 
-	for (var i=0; i<artboards.length(); i++) {
-		var artboard = artboards[i];
-		var layergroups = [artboard layers];
+	if (artboards.length()) {	  // if this page has artboards...
+		for (var i=0; i<artboards.length(); i++) {
+			var artboard = artboards[i];
+			var layers = [artboard layers];
 
-		for (var j=0; j<layergroups.length();j++){
-			var layergroup = layergroups[j];
-			if ([[layergroup name] isEqualToString:layername]){
-				if ([layergroup isVisible]){
-					[layergroup setIsVisible:NO];
-				} else {
-					[layergroup setIsVisible:YES];
+			for (var j=0; j<layers.length();j++){
+				var layer = [layers objectAtIndex: j];
+				if ([[layer name] isEqualToString:layername]){
+					// determine whether to toggle all specs on or off
+					if (visibility == nil) {
+						visibility = [layer isVisible] ? false : true;
+					}
+
+					[layer setIsVisible: visibility];
 				}
+			}	
+		}		
+	} else {  // if this page doesn't have artboards...
+		var layers = [page layers];
+
+		for (var j=0; j<layers.length();j++){
+			var layer = [layers objectAtIndex: j];
+			if ([[layer name] isEqualToString:layername]){
+				// determine whether to toggle all specs on or off
+				if (visibility == nil) {
+					visibility = [layer isVisible] ? false : true;
+				}
+
+				[layer setIsVisible: visibility];
 			}
 		}	
-	}	
+	}
 }


### PR DESCRIPTION
1) Fixed issue where NO and YES are unrecognized (changed to 'false' and 'true')
2) Fixed issue where array indexing "layergroups[i]" caused error (changed to use objectAtIndex)
3) Updated code to also work for pages that do not use artboards (rare, perhaps, but worth fixing)
4) Updated code to determine a unified toggle direction for all specs (I hit a situation where I had toggled one spec off manually, after which the plugin would hide all specs and toggle that one back on -- undesirable)
5) This code doesn't distinguish between layers and layergroups -- operates on any layer named "specs", so to not be misleading I changed the iterator variable from "layergroups" to "layers"
6) Changed variable name "currentPage" to simply "page" for consistency with the rest of the variable names